### PR TITLE
Updated Icon URL and Web Manifest for iOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,8 +17,8 @@
   <meta name="image" property="og:image" content="https://sit.potato.horse/social.png" />
   <meta name="author" content="Rafal Pastuszak" />
 
-  <link rel="shortcut icon" type="image/svg" sizes="any" href="/src/assets/favicon.svg" />
-  <link rel="apple-touch-icon" href="/src/assets/apple-touch-icon-180x180.png" />
+  <link rel="shortcut icon" type="image/svg" sizes="any" href="/favicon.svg" />
+  <link rel="apple-touch-icon" href="/apple-touch-icon-180x180.png" />
 
 
   <link rel="canonical" href="https://sit.sonnet.io" />

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -14,6 +14,7 @@ export default defineConfig({
         name: "Sit.",
         short_name: "Sit.",
         orientation: "portrait",
+        displayMode: "standalone",
         theme_color: "#000000",
         icons: [
           {


### PR DESCRIPTION
I noticed on iOS that the PWA version of the application didn't act as a standalone application but displayed in a web browser UI. This broke the immersion of the application which I thought wasn't ideal.

This change fixes that by adding "display: standalone". It also fixes the urls for the icons.